### PR TITLE
FEATURE: when suggesting usernames skip input that consist entirely of disallowed characters

### DIFF
--- a/lib/discourse_code_review/github_user_syncer.rb
+++ b/lib/discourse_code_review/github_user_syncer.rb
@@ -43,7 +43,7 @@ module DiscourseCodeReview
 
         User.create!(
           email: email,
-          username: UserNameSuggester.suggest(username.presence || email),
+          username: UserNameSuggester.suggest(username, email),
           name: name.presence || User.suggest_name(email),
           staged: true
         )


### PR DESCRIPTION
Starting from https://github.com/discourse/discourse/commit/c2022521906b3c44a8a21e8eb2527c8650e06a18 we can pass to `UsernameSuggester` an array of inputs parameters and it'll be skipping invalid items and trying next ones.